### PR TITLE
feat: auto release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release Obsidian Plugin
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  PLUGIN_NAME: Flowershow
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+
+      - name: Build
+        id: build
+        run: |
+          npm install
+          npm run build
+          mkdir ${{ env.PLUGIN_NAME }}
+          cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
+          zip -r ${{ env.PLUGIN_NAME }}-${{ github.ref_name }}.zip ${{ env.PLUGIN_NAME }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            ${{ env.PLUGIN_NAME }}-${{ github.ref_name }}.zip
+            main.js
+            manifest.json
+            styles.css


### PR DESCRIPTION
Resolve #12 

## Example
github release page: https://github.com/laojianzi/obsidian-flowershow/releases/tag/1.0.0
github action page: https://github.com/laojianzi/obsidian-flowershow/actions/runs/5400102865/jobs/9808093892


## Guide
You can choose any of the following methods to trigger an auto-release.

option 1: using git cli
```bash
git tag -a 1.0.1 -m "1.0.1"
git push origin 1.0.1
```

option 2: new a releases in github repo
you can [click me](https://github.com/datopian/obsidian-flowershow/releases/new)
