### PR TITLE
fix: scope checkbox CSS to avoid conflicting with other plugins

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@ If your plugin does not need CSS, delete this file.
 */
 
 /* Reapplies Mui styles that get overriden by Obsidian styles */
-.modal-content input[type="checkbox"] {
+.publish-status-view input[type="checkbox"] {
   cursor: inherit;
   position: absolute;
   opacity: 0;
@@ -20,7 +20,7 @@ If your plugin does not need CSS, delete this file.
   z-index: 1;
 }
 
-.MuiCheckbox-root .MuiSvgIcon-root {
+.publish-status-view .MuiCheckbox-root .MuiSvgIcon-root {
   color: var(--text-faint);
 }
 


### PR DESCRIPTION
## Summary
- Closes #34
- The CSS selector `.modal-content input[type="checkbox"]` was too broad and overrode checkbox styles across **all** Obsidian modals, breaking other plugins (e.g. multi-properties).
- Scoped both rules to `.publish-status-view`, which is the root container `PublishStatusModal` adds via `container.addClass("publish-status-view")` — so the styles only apply inside the Flowershow modal.

## Test plan
- [ ] Open the Flowershow publish status modal — checkboxes in the file tree should still function correctly
- [ ] Open another plugin's modal with checkboxes (e.g. multi-properties) — checkboxes should no longer be affected by Flowershow's CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)