### PR TITLE
chore: remove unused runtime dependencies

### DIFF
--- a/.changeset/quiet-axes-retire.md
+++ b/.changeset/quiet-axes-retire.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Remove unused runtime dependencies left over from the pre-v4 GitHub-publishing era (`axios`, `@octokit/core`, `@octokit/rest`, `@sindresorhus/slugify`, `github-slugger`, `luxon`, and `@types/luxon`). None were imported anywhere; removing them trims install time and supply-chain surface.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.13",
     "@changesets/cli": "^2.29.7",
-    "@types/luxon": "^3.7.1",
     "@types/node": "^24.7.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.1",
@@ -36,12 +35,6 @@
     "@mui/icons-material": "^7.3.4",
     "@mui/material": "^7.3.4",
     "@mui/x-tree-view": "^8.14.0",
-    "@octokit/core": "^7.0.5",
-    "@octokit/rest": "^22.0.0",
-    "@sindresorhus/slugify": "^3.0.0",
-    "axios": "^1.12.2",
-    "github-slugger": "^2.0.0",
-    "luxon": "^3.7.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   }


### PR DESCRIPTION
## Summary

Removes seven runtime/types dependencies that aren't imported anywhere in the codebase. They're leftovers from the pre-v4 plugin (which published via GitHub) and have been carrying along through subsequent releases.

| Removed                    | Last meaningful use                  |
| -------------------------- | ------------------------------------ |
| `axios`                    | HTTP, superseded by `requestUrl`     |
| `@octokit/core`            | GitHub API                           |
| `@octokit/rest`            | GitHub API                           |
| `@sindresorhus/slugify`    | Filename slugging                    |
| `github-slugger`           | Filename slugging                    |
| `luxon`                    | Date formatting                      |
| `@types/luxon`             | Types for the above                  |

Verified via `grep -rn` across `src/` and `main.ts` — zero references. `npm install`, `npm run build`, and `npm test` (116 cases) all pass.

## Test plan

- [x] `npm install` succeeds and removes 46 transitive packages
- [x] `npm run build` produces `main.js` of unchanged size (~1.7 MB)
- [x] `npm test` — 116/116 pass
- [ ] Reviewer: confirm nothing in your local workflow imports these

Includes a changeset (`patch` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)