### PR TITLE
fix: compute git blob SHA so published files stop showing as "Changed"

### DIFF
--- a/.changeset/spotty-status-heal.md
+++ b/.changeset/spotty-status-heal.md
@@ -1,0 +1,5 @@
+---
+"flowershow": patch
+---
+
+Fix published files always showing as "Changed" in the publish status view. The plugin computed a plain `SHA-1` of file content, but the server stores and compares a **git blob** SHA-1 (`SHA-1("blob " + byteLength + "\0" + content)`, matching the CLI and `git hash-object`). The two never matched, so every published file was reported as changed forever. Both `calculateFileSha` and `calculateTextSha` now produce the git blob SHA. No republish is needed after updating — the next status refresh reconciles automatically.

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { calculateFileSha, calculateTextSha } from "./index";
+
+/**
+ * The server stores Blob.sha as a *git blob* SHA-1
+ * (`SHA-1("blob " + byteLength + "\0" + content)`), computed by the Cloudflare
+ * worker's computeGitBlobSha() and matched by the Go CLI's sha1Hex(). The
+ * plugin sends its own SHA to the /sync and /files endpoints, so it must use
+ * the identical algorithm or every published file is reported as "Changed"
+ * forever (see issue #1310).
+ *
+ * These expected values are `git hash-object` of the exact content.
+ */
+describe("git blob SHA compatibility with server", () => {
+  it("calculateTextSha matches git hash-object for text", async () => {
+    // printf '# My new blog post\n\nHello world\n' | git hash-object --stdin
+    const text = "# My new blog post\n\nHello world\n";
+    expect(await calculateTextSha(text)).toBe(
+      "c51e3b0a743630c2259c5ed784c42561ba0c7738",
+    );
+  });
+
+  it("calculateTextSha matches git hash-object for an empty string", async () => {
+    // git hash-object of empty content
+    expect(await calculateTextSha("")).toBe(
+      "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+    );
+  });
+
+  it("calculateFileSha matches git hash-object for bytes", async () => {
+    // printf '# My new blog post\n\nHello world\n' | git hash-object --stdin
+    const bytes = new TextEncoder().encode("# My new blog post\n\nHello world\n");
+    expect(await calculateFileSha(bytes)).toBe(
+      "c51e3b0a743630c2259c5ed784c42561ba0c7738",
+    );
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,9 +18,26 @@ async function digest(
 }
 
 /**
- * Calculate SHA-1 hash of file content
+ * Calculate the git blob SHA-1 of raw bytes.
+ *
+ * This MUST match the server contract: the Cloudflare worker stores
+ * `Blob.sha` as `SHA-1("blob " + byteLength + "\0" + content)` (see the
+ * worker's computeGitBlobSha) and the Go CLI sends the same. A plain SHA-1
+ * of the content would never match, so /sync would report every published
+ * file as "Changed" forever (issue #1310).
+ */
+async function calculateGitBlobSha(content: Uint8Array): Promise<string> {
+  const header = new TextEncoder().encode(`blob ${content.length}\0`);
+  const combined = new Uint8Array(header.length + content.length);
+  combined.set(header);
+  combined.set(content, header.length);
+  return digest("SHA-1", combined);
+}
+
+/**
+ * Calculate the git blob SHA-1 of binary file content.
  * @param content - File content as ArrayBuffer or Uint8Array
- * @returns SHA-1 hash as hex string
+ * @returns git blob SHA-1 hash as hex string
  */
 export async function calculateFileSha(
   content: ArrayBuffer | Uint8Array,
@@ -29,18 +46,18 @@ export async function calculateFileSha(
   const data =
     content instanceof ArrayBuffer ? new Uint8Array(content) : content;
 
-  return digest("SHA-1", data);
+  return calculateGitBlobSha(data);
 }
 
 /**
- * Calculate SHA-1 hash of text content
+ * Calculate the git blob SHA-1 of text content.
  * @param text - Text content as string
- * @returns SHA-1 hash as hex string
+ * @returns git blob SHA-1 hash as hex string
  */
 export async function calculateTextSha(text: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(text);
-  return digest("SHA-1", data);
+  return calculateGitBlobSha(data);
 }
 
 export class FlowershowError extends Error {


### PR DESCRIPTION
## Problem

Fixes flowershow/flowershow#1310 — after a successful publish, the plugin's publish status view keeps listing files under **Changed**, even after manual refresh. The content is live on the site; only the status is wrong, and it never clears.

## Root cause

Change detection compares each local file's SHA against the server's stored `Blob.sha` via `POST /sync?dryRun=true`. The server stores a **git blob SHA-1** — `SHA-1("blob " + byteLength + "\0" + content)` — written by the Cloudflare worker (`computeGitBlobSha`) and produced identically by the Go CLI (`sha1Hex`) and `git hash-object`.

The plugin instead sent a **plain** `SHA-1(content)` (no git blob header) from `calculateFileSha` / `calculateTextSha`. The two hashes never match, so every published file falls into `toUpdate` and is shown as "Changed" indefinitely.

```
content: "# My new blog post\n\nHello world\n"
plugin (plain SHA-1) : 8dff786f1d8244463a47f5e88722d5d15dfaf2fb
server / git hash-object (git blob SHA): c51e3b0a743630c2259c5ed784c42561ba0c7738
```

## Fix

Route both `calculateFileSha` and `calculateTextSha` through a shared `calculateGitBlobSha` helper that prepends the `blob <byteLength>\0` header before the SHA-1 digest, matching the server/CLI contract.

**No migration or republish needed:** the stored `Blob.sha` values are already git blob SHAs, so the next status refresh reconciles existing sites automatically.

## Tests

- New `src/utils/index.test.ts` pins both functions to `git hash-object` output (text, empty string, and binary bytes). Red before the fix, green after.
- Full suite: **121/121 pass**; `tsc -noEmit` clean.